### PR TITLE
[EBR2-105] Fix start_nrp_docker.sh bootstrap footguns

### DIFF
--- a/nrp_variables
+++ b/nrp_variables
@@ -91,7 +91,8 @@ export NRP_SIMULATION_DIR=/tmp/nrp-simulation-dir
 export GAZEBO_MODEL_PATH=$NRP_SIMULATION_DIR/assets:$HOME/.gazebo/models:$GAZEBO_MODEL_PATH
 
 # NRP local storage path
-export STORAGE_PATH=$HOME/.opt/nrpStorage
+# Soft default: honor a value the user already exported instead of clobbering it.
+export STORAGE_PATH=${STORAGE_PATH:-$HOME/.opt/nrpStorage}
 
 # General NRP
 export NRP_USER=$USER

--- a/start_nrp_docker.sh
+++ b/start_nrp_docker.sh
@@ -114,7 +114,9 @@ if storage_bootstrap_needed; then
     trap - INT TERM EXIT
     exit 1
   fi
-  docker compose -f "$DOCKER_COMPOSE_FILE" down
+  # Guarded: a non-zero exit from teardown (e.g. nothing to remove) must not
+  # abort the script under `set -e` before the trap is cleared below.
+  docker compose -f "$DOCKER_COMPOSE_FILE" down || true
 
   trap - INT TERM EXIT
 

--- a/start_nrp_docker.sh
+++ b/start_nrp_docker.sh
@@ -135,6 +135,11 @@ for a in "$@"; do
     --foreground|-f)
       mode="foreground"
       ;;
+    --wait)
+      # Documented flag; the detached path already passes --wait to compose.
+      # Consume it here so it isn't forwarded a second time via extra_args.
+      mode="wait"
+      ;;
     --)
       ;;
     *)

--- a/start_nrp_docker.sh
+++ b/start_nrp_docker.sh
@@ -102,7 +102,11 @@ if storage_bootstrap_needed; then
   trap 'bootstrap_rollback' EXIT
 
   echo "Bootstrapping FS storage at $STORAGE_PATH (creating user 'nrpuser')..."
-  if ! docker compose -f "$DOCKER_COMPOSE_FILE" run --rm nrp-proxy-service \
+  # --no-deps: createFSUser.ts only writes the TingoDB `users` file into the
+  # mounted $STORAGE_PATH from inside the proxy container; it needs no other
+  # running service. Without it, compose would also start nrp-proxy-service's
+  # dependency chain — the multi-GB nest-gazebo backend — just to write a file.
+  if ! docker compose -f "$DOCKER_COMPOSE_FILE" run --rm --no-deps nrp-proxy-service \
         node_modules/ts-node/dist/bin.js utils/createFSUser.ts \
         --user nrpuser --password password; then
     echo "createFSUser failed; rolling back." >&2

--- a/start_nrp_docker.sh
+++ b/start_nrp_docker.sh
@@ -102,7 +102,7 @@ if storage_bootstrap_needed; then
   trap 'bootstrap_rollback' EXIT
 
   echo "Bootstrapping FS storage at $STORAGE_PATH (creating user 'nrpuser')..."
-  if ! docker compose run --rm nrp-proxy-service \
+  if ! docker compose -f "$DOCKER_COMPOSE_FILE" run --rm nrp-proxy-service \
         node_modules/ts-node/dist/bin.js utils/createFSUser.ts \
         --user nrpuser --password password; then
     echo "createFSUser failed; rolling back." >&2
@@ -110,7 +110,7 @@ if storage_bootstrap_needed; then
     trap - INT TERM EXIT
     exit 1
   fi
-  docker compose down
+  docker compose -f "$DOCKER_COMPOSE_FILE" down
 
   trap - INT TERM EXIT
 


### PR DESCRIPTION
Fixes bootstrap footguns in `start_nrp_docker.sh` (and its sourced
`nrp_variables`). Ticket: https://hbpneurorobotics.atlassian.net/browse/EBR2-105

## Fixes

1. **createFSUser bootstrap no longer boots the whole backend.** The
   first-run `docker compose run nrp-proxy-service … createFSUser.ts`
   lacked `--no-deps`, so compose started `nrp-proxy-service`'s dependency
   chain — the multi-GB `nest-gazebo` backend — just to write the TingoDB
   `users` file. `createFSUser.ts` writes directly into the mounted
   `$STORAGE_PATH` from inside the proxy container and needs no other running
   service, so `--no-deps` is safe and drops only the backend start.

2. **`STORAGE_PATH` is no longer clobbered.** `nrp_variables` unconditionally
   `export STORAGE_PATH=$HOME/.opt/nrpStorage`, overriding a user-set value.
   Changed to the soft default `${STORAGE_PATH:-$HOME/.opt/nrpStorage}` (same
   default) so a pre-set value is honored.

3. **Selected compose file is now respected during bootstrap.** The bootstrap
   `run` and `down` omitted `-f "$DOCKER_COMPOSE_FILE"`, so they always acted on
   the default `docker-compose.yaml` even in nest-desktop mode
   (`NRP_NEST_DESKTOP=ON`). Both now pass the selected compose file, matching
   the stack-boot path.

4. **`--wait` is no longer double-passed.** The documented `--wait` flag fell
   through the arg-parser's catch-all into `extra_args`, so it was forwarded to
   `docker compose up -d --wait` a second time (`--wait --wait`). It is now
   consumed explicitly.

5. **Bootstrap `down` guarded under `set -e`.** The bare `docker compose down`
   after `createFSUser` ran under `set -euo pipefail`; a non-fatal non-zero exit
   would abort the script before the trap was cleared, triggering the rollback
   of the just-created FS storage. Guarded with `|| true`.

## Verification

- `bash -n start_nrp_docker.sh` and `bash -n nrp_variables` pass.
- Arg-parsing checked in isolation: `--wait` is consumed (not re-forwarded),
  pass-through args (`--`, `--scale`, `--pull`) preserved, `--foreground`
  still selects foreground mode.
- `docker compose config` validates for both `docker-compose.yaml` and
  `docker-compose-nest-desktop.yaml`.

**End-to-end check:** the full husky acceptance gate
(`tests/run_acceptance.sh`, UI + CLI against a live stack) is the definitive
check for this change and should be run on it — it exercises the real bootstrap
happy path and asserts the sim clock advances. Not run here (heavy nest-gazebo
image pull + local host `:9000` conflict); please run the gate before merge.
