### PR TITLE
[EBR2-107] Fix docker-compose-build.yaml for build-from-source

### DIFF
--- a/docker-compose-build.yaml
+++ b/docker-compose-build.yaml
@@ -1,58 +1,98 @@
-version: '3.9'
-
+# [EBR2-107] Build-from-source variant of docker-compose.yaml.
+#
+# Identical topology, container names, ports, volumes, environment and
+# healthcheck wiring to docker-compose.yaml — the ONLY difference is that
+# nrp-frontend/nrp-proxy/nrp-backend are built from the sibling submodule
+# sources (${HBP}/nrp-frontend, ${HBP}/nrp-proxy, ${HBP}/nrp-backend)
+# instead of pulled from Docker Hub. mqtt-broker and haproxy stay as plain
+# upstream images.
+#
+# The built images are tagged with the SAME names/tags the runtime compose
+# expects (nrp-frontend:development, nrp-proxy:development,
+# nrp-backend:nest-gazebo). So:
+#     docker compose -f docker-compose-build.yaml build
+# produces local images that docker-compose.yaml (and start_nrp_docker.sh)
+# pick up directly for reuse.
+#
+# Usage:
+#     docker compose -f docker-compose-build.yaml build       # build all
+#     docker compose -f docker-compose-build.yaml up -d --wait # build+run
 services:
+  mqtt-broker-service:
+    image: eclipse-mosquitto
+    volumes:
+      - ${HBP}/nrp-user-scripts/config_files/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf
+    # [EBR2-86] No hardcoded container_name. It collided with the identically
+    # named `mqtt-broker` container declared by nrp-core example compose
+    # projects: `docker compose run/up` would adopt and stop that project's
+    # containers. Other services reach the broker via its compose service
+    # alias `mqtt-broker-service`.
+
+  haproxy-service:
+    image: haproxy:2.7
+    container_name: nrp-haproxy
+    volumes:
+      - ${HBP}/nrp-user-scripts/config_files/haproxy/local_docker/haproxy.docker.cfg:/usr/local/etc/haproxy/haproxy.cfg
+      - ${HBP}/nrp-user-scripts/config_files/haproxy/cors.lua:/usr/local/etc/haproxy/lua_scripts/cors.lua
+    ports:
+      - 9000:9000
+    depends_on:
+      nrp-proxy-service:
+        condition: service_healthy
 
   nrp-frontend-service:
-    image: ${NRP_DOCKER_REGISTRY:-docker.io/hbpneurorobotics/}nrp-frontend${NRP_IMAGE_TAG}
+    image: ${NRP_DOCKER_REGISTRY:-docker.io/hbpneurorobotics/}nrp-frontend:development
     container_name: nrp-frontend
     build:
       context: ${HBP}/nrp-frontend
+    # TODO: [NRRPLT-8789] Configuration not working
+    # volumes:
+      # - ${HBP}/nrp-user-scripts/config_files/nrp-frontend/config.json.local.docker:/nrp-frontend-app/build/config.json
+
 
   nrp-proxy-service:
-    image: ${NRP_DOCKER_REGISTRY:-docker.io/hbpneurorobotics/}nrp-proxy${NRP_IMAGE_TAG}
+    image: ${NRP_DOCKER_REGISTRY:-docker.io/hbpneurorobotics/}nrp-proxy:development
     container_name: nrp-proxy
     build:
       context: ${HBP}/nrp-proxy
+    volumes:
+      - ${HBP}/nrp-user-scripts/config_files/nrp-proxy/config.json.local.docker:/nrp-proxy-app/config.json
+      - ${HBP}/nrp-core/templates:/nrp-templates:ro
+      - ${STORAGE_PATH}:/nrpStorage
+    depends_on:
+      nrp-backend-service:
+        condition: service_healthy
 
-  nrp-haproxy-service:
-    image: ${NRP_DOCKER_REGISTRY:-docker.io/hbpneurorobotics/}nrp-haproxy${NRP_IMAGE_TAG}
-    container_name: nrp-haproxy
-    build:
-      context: ${HBP}/nrp-user-scripts
-      dockerfile: nrp-haproxy.Dockerfile
-
-  nrp-gazebo-nest-service:
-    image: ${NRP_DOCKER_REGISTRY:-docker-registry.ebrains.eu/neurorobotics/}nrp/nrp-core/backend-nrp-gazebo-nest-ubuntu20${NRP_IMAGE_TAG}
-    build:
-      context: ${HBP}/nrp-backend
-      args:
-        - BASE_IMAGE=${NRP_DOCKER_REGISTRY:-docker-registry.ebrains.eu/neurorobotics/}nrp-core/nrp-gazebo-nest-ubuntu20${NRP_CORE_TAG:-$NRP_IMAGE_TAG}
-
-  nrp-xpra-gazebo-nest-service:
-    image: ${NRP_DOCKER_REGISTRY:-docker-registry.ebrains.eu/neurorobotics/}nrp/nrp-core/backend-nrp-xpra-gazebo-nest-ubuntu20${NRP_IMAGE_TAG}
+  nrp-backend-service:
+    # The backend tag selects the nrp-core variant: `nest-gazebo` ships
+    # Gazebo + NEST (needed by most templates). Swap to `vanilla` for the
+    # slim no-simulator image. Frontend/proxy are variant-agnostic and
+    # pinned to `:development` above.
+    image: ${NRP_DOCKER_REGISTRY:-docker.io/hbpneurorobotics/}nrp-backend:nest-gazebo
+    container_name: nrp-backend
     build:
       context: ${HBP}/nrp-backend
       args:
-        - BASE_IMAGE=${NRP_DOCKER_REGISTRY:-docker-registry.ebrains.eu/neurorobotics/}nrp-core/nrp-xpra-gazebo-nest-ubuntu20${NRP_CORE_TAG:-$NRP_IMAGE_TAG}
+        # BASE_IMAGE selects the nrp-core runtime the backend is layered on.
+        # nest-gazebo is the Dockerfile default and the variant most templates
+        # need; match how GitHub Actions builds it (Ubuntu 20.04 dropped in
+        # EBR2-81, so no `-ubuntu20` suffix). Override to nrp-vanilla for the
+        # slim image.
+        BASE_IMAGE: ${NRP_DOCKER_REGISTRY:-docker.io/hbpneurorobotics/}nrp-nest-gazebo:latest
+    environment:
+      STORAGE_ADDRESS: nrp-haproxy
+      STORAGE_PORT: 9000
+      NRP_MQTT_BROKER_ADDRESS: mqtt-broker-service:1883
+      NRP_XPRA_PORT: ${NRP_XPRA_PORT:-9876}
+      NRP_DISPLAY: ${NRP_DISPLAY:-100}
+    ports:
+      - 9876:9876
+    volumes:
+      - ${HBP}/nrp-user-scripts/config_files/nginx.docker/uwsgi-nrp.ini:/usr/uwsgi-nrp.ini
+      - ${HBP}/nrp-user-scripts/config_files/nginx.docker/nginx.conf:/etc/nginx/nginx.conf
+      - ${HBP}/nrp-user-scripts/config_files/nginx.docker/conf.d/nrp-services.conf:/etc/nginx/conf.d/nrp-services.conf
+      - ${HBP}/nrp-core/templates:/nrp-templates:ro
 
-  nrp-vanilla-service:
-    image: ${NRP_DOCKER_REGISTRY:-docker-registry.ebrains.eu/neurorobotics/}nrp/nrp-core/backend-nrp-vanilla-ubuntu20${NRP_IMAGE_TAG}
-    build:
-      context: ${HBP}/nrp-backend
-      args:
-        - BASE_IMAGE=${NRP_DOCKER_REGISTRY:-docker-registry.ebrains.eu/neurorobotics/}nrp-core/nrp-vanilla-ubuntu20${NRP_CORE_TAG:-$NRP_IMAGE_TAG}
-
-  nrp-opensim-tvb-service:
-    image: ${NRP_DOCKER_REGISTRY:-docker-registry.ebrains.eu/neurorobotics/}nrp/nrp-core/backend-nrp-opensim-tvb-ubuntu20${NRP_IMAGE_TAG}
-    build:
-      context: ${HBP}/nrp-backend
-      args:
-        - BASE_IMAGE=${NRP_DOCKER_REGISTRY:-docker-registry.ebrains.eu/neurorobotics/}nrp-core/nrp-opensim-tvb-ubuntu20${NRP_CORE_TAG:-$NRP_IMAGE_TAG}
-
-  nrp-xpra-opensim-tvb-service:
-    image: ${NRP_DOCKER_REGISTRY:-docker-registry.ebrains.eu/neurorobotics/}nrp/nrp-core/backend-nrp-xpra-opensim-tvb-ubuntu20${NRP_IMAGE_TAG}
-    build:
-      context: ${HBP}/nrp-backend
-      args:
-        - BASE_IMAGE=${NRP_DOCKER_REGISTRY:-docker-registry.ebrains.eu/neurorobotics/}nrp-core/nrp-xpra-opensim-tvb-ubuntu20${NRP_CORE_TAG:-$NRP_IMAGE_TAG}
-  
+# Template experiments are sourced from the nrp-core submodule's templates/
+# directory by default. Override $HBP or point this mount elsewhere to use
+# your own template set.


### PR DESCRIPTION
## What

Rewrites the stale `docker-compose-build.yaml` so build-from-source works again and mirrors the current runtime `docker-compose.yaml`.

Jira: https://hbpneurorobotics.atlassian.net/browse/EBR2-107

## Why

The build compose had drifted badly from the runtime `docker-compose.yaml`:

- built `nrp-haproxy` from a Dockerfile and declared six `-ubuntu20` nrp-core backend variants;
- defaulted to the retired `docker-registry.ebrains.eu/neurorobotics` registry;
- used dead `NRP_IMAGE_TAG` / `NRP_CORE_TAG` interpolations;
- referenced Ubuntu 20.04 base images that were dropped in EBR2-81.

It no longer matched the running stack and could not build.

## What changed

- Same services / container names / ports / volumes / environment / healthcheck-driven `depends_on` as `docker-compose.yaml` (`mqtt-broker-service`, `haproxy-service` → `nrp-haproxy`, `nrp-frontend-service` → `nrp-frontend`, `nrp-proxy-service` → `nrp-proxy`, `nrp-backend-service` → `nrp-backend`).
- `nrp-frontend` / `nrp-proxy` / `nrp-backend` now build from the sibling submodule sources (`${HBP}/nrp-frontend`, `${HBP}/nrp-proxy`, `${HBP}/nrp-backend`).
- Backend passes `BASE_IMAGE=<registry>nrp-nest-gazebo:latest` (the Dockerfile default / CI base; no `-ubuntu20`).
- `mqtt-broker` (`eclipse-mosquitto`) and `haproxy` (`haproxy:2.7`) stay plain upstream images.
- Dropped the dead `NRP_IMAGE_TAG` / `NRP_CORE_TAG` interpolations and the retired ebrains registry default.
- Built images are tagged with the same names the runtime compose expects (`nrp-frontend:development`, `nrp-proxy:development`, `nrp-backend:nest-gazebo`) so `start_nrp_docker.sh` reuses them directly.

## Verification

```
HBP=<repo-root> STORAGE_PATH=$HOME/.opt/nrpStorage \
  docker compose -f docker-compose-build.yaml config
```

resolves with no unset-var warnings/errors and shows the three `build:` contexts plus the backend `BASE_IMAGE` arg.

Smoke-built the light images (`docker compose -f docker-compose-build.yaml build nrp-frontend-service nrp-proxy-service`) — both build and tag as `nrp-frontend:development` / `nrp-proxy:development`. The heavy backend / nest-gazebo image was intentionally not built here.