### PR TITLE
[EBR2-116] Parameterize backend image tag (NRP_BACKEND_TAG)

### DIFF
--- a/SMOKE_TEST.md
+++ b/SMOKE_TEST.md
@@ -49,13 +49,18 @@ Coexisting compose projects (EBR2-86):
 ```bash
 export HBP=/home/$(whoami)/git-tum            # or wherever your clones live
 export STORAGE_PATH=$HOME/.opt/nrpStorage     # default; can be elsewhere
+export NRP_BACKEND_TAG=nest-gazebo            # default; set to `vanilla` for
+                                              # the slim no-simulator image
 ```
 
 `HBP` is the only required variable. Image registry/tags are baked into
 the compose files — frontend/proxy pull `:development`, backend pulls
 `:nest-gazebo` (Gazebo + NEST) — from `docker.io/hbpneurorobotics/` by
-default. Point at a mirror with `NRP_DOCKER_REGISTRY` if you must; there
-is no longer an `NRP_IMAGE_TAG` to set.
+default. Point at a mirror with `NRP_DOCKER_REGISTRY` if you must. The
+backend variant is the one per-service tag you can override: set
+`NRP_BACKEND_TAG=vanilla` to select the slim no-simulator image (default
+`nest-gazebo`). `start_nrp_docker.sh` exports the default for you, so
+`docker compose` interpolation is stable whether or not you set it.
 
 ### 2. Bring the stack up
 

--- a/docker-compose-nest-desktop.yaml
+++ b/docker-compose-nest-desktop.yaml
@@ -71,10 +71,10 @@ services:
 
   nrp-backend-service:
     # The backend tag selects the nrp-core variant: `nest-gazebo` ships
-    # Gazebo + NEST (needed by most templates). Swap to `vanilla` for the
-    # slim no-simulator image. Frontend/proxy are variant-agnostic and
-    # pinned to `:development` above.
-    image: ${NRP_DOCKER_REGISTRY:-docker.io/hbpneurorobotics/}nrp-backend:nest-gazebo
+    # Gazebo + NEST (needed by most templates). Set NRP_BACKEND_TAG=vanilla
+    # for the slim no-simulator image (default stays nest-gazebo). Frontend/
+    # proxy are variant-agnostic and pinned to `:development` above.
+    image: ${NRP_DOCKER_REGISTRY:-docker.io/hbpneurorobotics/}nrp-backend:${NRP_BACKEND_TAG:-nest-gazebo}
     container_name: nrp-backend
     environment:
       - STORAGE_ADDRESS=nrp-haproxy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,10 +42,10 @@ services:
 
   nrp-backend-service:
     # The backend tag selects the nrp-core variant: `nest-gazebo` ships
-    # Gazebo + NEST (needed by most templates). Swap to `vanilla` for the
-    # slim no-simulator image. Frontend/proxy are variant-agnostic and
-    # pinned to `:development` above.
-    image: ${NRP_DOCKER_REGISTRY:-docker.io/hbpneurorobotics/}nrp-backend:nest-gazebo
+    # Gazebo + NEST (needed by most templates). Set NRP_BACKEND_TAG=vanilla
+    # for the slim no-simulator image (default stays nest-gazebo). Frontend/
+    # proxy are variant-agnostic and pinned to `:development` above.
+    image: ${NRP_DOCKER_REGISTRY:-docker.io/hbpneurorobotics/}nrp-backend:${NRP_BACKEND_TAG:-nest-gazebo}
     container_name: nrp-backend
     environment:
       STORAGE_ADDRESS: nrp-haproxy

--- a/start_nrp_docker.sh
+++ b/start_nrp_docker.sh
@@ -12,15 +12,19 @@
 #   HBP                  — path to the parent dir holding nrp-user-scripts
 # Optional env:
 #   STORAGE_PATH         — default $HOME/.opt/nrpStorage
-#   NRP_DOCKER_REGISTRY  — default docker.io/hbpneurorobotics/ ; the only
-#                          image knob. Per-service tags are pinned in the
-#                          compose files (frontend/proxy :development,
-#                          backend :nest-gazebo), so no NRP_IMAGE_TAG.
+#   NRP_DOCKER_REGISTRY  — default docker.io/hbpneurorobotics/ ; overrides the
+#                          image registry/namespace for every service.
+#   NRP_BACKEND_TAG      — backend image tag = nrp-core variant, default
+#                          nest-gazebo. Set to `vanilla` for the slim
+#                          no-simulator image. Frontend/proxy stay :development.
 #   NRP_NEST_DESKTOP     — set to ON to use docker-compose-nest-desktop.yaml
 
 set -euo pipefail
 
 export NRP_DOCKER_REGISTRY="${NRP_DOCKER_REGISTRY:-docker.io/hbpneurorobotics/}"
+# Exported so compose interpolation is stable even when unset; default keeps
+# the nest-gazebo variant. Set NRP_BACKEND_TAG=vanilla for the slim image.
+export NRP_BACKEND_TAG="${NRP_BACKEND_TAG:-nest-gazebo}"
 
 if [ -z "${HBP:-}" ]; then
   echo "Your HBP variable is not set!" >&2


### PR DESCRIPTION
## What

Make the `nrp-backend` image **TAG** overridable so a demo run can select the
nrp-core variant (`nest-gazebo` vs `vanilla`) without editing compose.

- `docker-compose.yaml`: backend image is now
  `${NRP_DOCKER_REGISTRY:-docker.io/hbpneurorobotics/}nrp-backend:${NRP_BACKEND_TAG:-nest-gazebo}`.
  The default is unchanged, so resolved output is **byte-identical** to before.
- `start_nrp_docker.sh`: exports `NRP_BACKEND_TAG` (default `nest-gazebo`) so
  compose interpolation is stable when the var is unset, and fixes the
  now-misleading optional-env comment that claimed per-service tags are pinned
  (no `NRP_IMAGE_TAG`).
- `SMOKE_TEST.md`: documents the `NRP_BACKEND_TAG` knob in the "Set environment"
  step (replacing the stale "no `NRP_IMAGE_TAG`" note).

Single-variant selector only. Concurrent multi-variant serving is out of scope
(separate L ticket). Default (`nest-gazebo`) behaviour is unchanged, so the
husky acceptance gate is unaffected.

## Verification

- `bash -n start_nrp_docker.sh` passes.
- `docker compose -f docker-compose.yaml config` resolves cleanly:
  - default → `docker.io/hbpneurorobotics/nrp-backend:nest-gazebo`
  - `NRP_BACKEND_TAG=vanilla` → `docker.io/hbpneurorobotics/nrp-backend:vanilla`
- Full husky gate with the default is run by the orchestrator.

Ticket: https://hbpneurorobotics.atlassian.net/browse/EBR2-116