### PR TITLE
[EBR2-122] Acceptance: open experiment files panel, assert no error dialog

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -8,7 +8,7 @@ by the same pytest runner:
 | Suite | File | What it proves |
 | --- | --- | --- |
 | CLI / REST | `acceptance/test_cli_experiment.py` | Drives the proxy + nrp-services REST API the way the frontend does: authenticate → clone → create → start → assert the simulation reaches `started`, the **simulation clock advances**, MQTT status events flow, and no `runtime_error` is published → stop. |
-| UI (Playwright) | `acceptance/test_ui_experiment.py` | Drives the real frontend in a headless browser: FS login → open the Experiments overview → Open a husky experiment → **Initialize + Start** in the workbench → assert no error status and the on-screen simulation clock advances. |
+| UI (Playwright) | `acceptance/test_ui_experiment.py` | Drives the real frontend in a headless browser: FS login → open the Experiments overview → Open a husky experiment → **Initialize + Start** in the workbench → assert no error status and the on-screen simulation clock advances. Also opens the **Edit experiment files** (TF editor) panel and asserts the files load with **no "Could not load the experiment files." error dialog** — the regression net for EBR2-122. |
 
 `husky_gate.sh` remains as a fast bash smoke check; these pytest suites are the
 thorough gate (the CLI suite is its structured, deeper-asserting successor).

--- a/tests/acceptance/test_ui_experiment.py
+++ b/tests/acceptance/test_ui_experiment.py
@@ -36,6 +36,24 @@ def _sim_time_boxes(page):
             if el.is_visible()]
 
 
+def _open_husky_experiment(page):
+    """Log in and open a husky experiment's workbench (the shared UI preamble).
+
+    Mirrors the steps a person takes: log in, open the Experiments overview,
+    select a husky entry and Open it, then land on the workbench route.
+    """
+    _login(page)
+
+    # Open the Experiments overview (My Experiments tab is the default).
+    page.click("text=EXPERIMENTS")
+    page.wait_for_selector(".list-entry-wrapper", timeout=30000)
+
+    # Select the first husky experiment entry, then Open its workbench.
+    page.locator(".list-entry-wrapper", has_text="husky").first.click()
+    page.get_by_role("button", name="Open").first.click()
+    page.wait_for_url("**/experiment/**", timeout=30000)
+
+
 @pytest.fixture
 def ui_cleanup(nrp, husky_experiment):
     """Ensure at least one husky experiment exists (husky_experiment), and stop
@@ -58,16 +76,7 @@ def test_launch_husky_through_ui(page, ui_cleanup):
     simulation) and Start (Play). We assert no error status is shown and the
     simulation clock advances — proving nrp-core is stepping behind the UI.
     """
-    _login(page)
-
-    # Open the Experiments overview (My Experiments tab is the default).
-    page.click("text=EXPERIMENTS")
-    page.wait_for_selector(".list-entry-wrapper", timeout=30000)
-
-    # Select the first husky experiment entry, then Open its workbench.
-    page.locator(".list-entry-wrapper", has_text="husky").first.click()
-    page.get_by_role("button", name="Open").first.click()
-    page.wait_for_url("**/experiment/**", timeout=30000)
+    _open_husky_experiment(page)
 
     # Initialize the simulation (creates it on the backend), then Start it.
     page.wait_for_selector('button[title="Initialize experiment"]:not([disabled])', timeout=30000)

--- a/tests/acceptance/test_ui_experiment.py
+++ b/tests/acceptance/test_ui_experiment.py
@@ -12,9 +12,16 @@ import time
 
 import pytest
 
-from conftest import BASE_URL, FS_USER, FS_PASSWORD
+from conftest import BASE_URL, FS_USER, FS_PASSWORD, HUSKY_CONFIG
 
 pytestmark = pytest.mark.ui
+
+# The error dialog (error-dialog.js) renders only while an error is queued, so
+# its mere presence is a failure signal. This exact message is raised by the
+# TF/files editor (tf-editor.js dataError) when the experiment files fail to
+# load — the regression EBR2-122 guards against.
+ERROR_DIALOG = ".error-dialog"
+FILES_LOAD_ERROR = "Could not load the experiment files."
 
 
 def _login(page):
@@ -52,6 +59,20 @@ def _open_husky_experiment(page):
     page.locator(".list-entry-wrapper", has_text="husky").first.click()
     page.get_by_role("button", name="Open").first.click()
     page.wait_for_url("**/experiment/**", timeout=30000)
+
+
+def _error_dialog_messages(page):
+    """Messages of any error dialog currently on screen (empty list when none)."""
+    return [el.inner_text().strip()
+            for el in page.query_selector_all(f"{ERROR_DIALOG} .error-dialog-message")]
+
+
+def _assert_no_error_dialog(page, context):
+    """Fail if an error dialog (or the files-load error text) is displayed."""
+    assert page.query_selector(ERROR_DIALOG) is None, \
+        f"an error dialog is shown {context}: {_error_dialog_messages(page) or '(no message)'}"
+    assert page.query_selector(f"text={FILES_LOAD_ERROR}") is None, \
+        f'"{FILES_LOAD_ERROR}" is shown {context}'
 
 
 @pytest.fixture
@@ -101,3 +122,41 @@ def test_launch_husky_through_ui(page, ui_cleanup):
             advanced = True
             break
     assert advanced, f"simulation clock did not advance in the UI (time boxes stuck at {before})"
+
+    # Cheap regression net: no error dialog surfaced anywhere in the launch flow.
+    _assert_no_error_dialog(page, "at the end of the launch flow")
+
+
+def test_experiment_files_panel_loads(page, husky_experiment):
+    """Open the 'Edit experiment files' panel and confirm the files load cleanly.
+
+    Regression net for EBR2-122: a "Could not load the experiment files."
+    TypeError shipped because the launch test opened the workbench but never
+    opened the files / TF-editor panel and never asserted the absence of an
+    error dialog. The panel reads the experiment's storage files independent of
+    a running simulation, so opening the workbench is enough to exercise it — no
+    Initialize/Start needed.
+    """
+    _open_husky_experiment(page)
+
+    # The 'Edit experiment files' (TF editor) panel is the workbench's default
+    # flexlayout tab, so it opens automatically. Its shell renders whether or not
+    # the file load succeeds, so waiting for it confirms the panel opened. We do
+    # not click the tab: a failed load pops a modal that would (correctly) block
+    # the click, so the failure is asserted below instead of hanging on it.
+    page.wait_for_selector(".flexlayout__tab_button:has-text('Edit experiment files')", timeout=30000)
+    page.wait_for_selector(".tf-editor-container", timeout=30000)
+
+    # Wait for the load to resolve: either the populated file selector (success)
+    # or the error dialog (failure), so a broken load fails here with a clear
+    # message instead of timing out.
+    page.wait_for_selector(
+        f'select[name="selectTFFile"] option[value="{HUSKY_CONFIG}"], {ERROR_DIALOG}',
+        state="attached", timeout=30000)
+
+    # (a) No error dialog / "Could not load the experiment files." surfaced.
+    _assert_no_error_dialog(page, "after opening the experiment files panel")
+
+    # (b) The files panel listed the experiment config file.
+    assert page.query_selector(f'select[name="selectTFFile"] option[value="{HUSKY_CONFIG}"]') is not None, \
+        f"the file selector does not list {HUSKY_CONFIG}"


### PR DESCRIPTION
## What

Extend the Playwright UI acceptance suite (`tests/acceptance/test_ui_experiment.py`) to exercise **opening an experiment's files** — the flow that broke and shipped untested — and assert no error dialog appears.

Ticket: https://hbpneurorobotics.atlassian.net/browse/EBR2-122

## Why

A real bug ("Could not load the experiment files." `TypeError`) shipped because the UI acceptance test opened the workbench and hit Initialize/Start but **never opened the experiment-files / TF-editor panel** and **never asserted the absence of an error dialog**. This PR adds the test that would have caught it. The frontend fix is a sibling PR.

## Changes (atomic commits)

1. **Extract shared workbench-open helper** — factor the login + open-experiment preamble of `test_launch_husky_through_ui` into `_open_husky_experiment()` (pure refactor, no behavior change) so the new test reuses the exact same steps.
2. **Add `test_experiment_files_panel_loads`** — opens the workbench (which auto-opens the "Edit experiment files" / TF-editor panel as its default flexlayout tab), waits for the file load to resolve, and asserts (a) no error dialog / "Could not load the experiment files." text is shown and (b) the file selector lists the experiment config (`simulation_config.json`). Also adds an `_assert_no_error_dialog()` guard at the end of `test_launch_husky_through_ui` as a cheap regression net over the whole launch flow. The panel reads storage files independent of a running simulation, so no Initialize/Start is needed.
3. **Docs** — update `tests/README.md` to describe the new coverage.

Resilient by design: explicit waits (no `sleep`); the load resolves on either the populated file selector (success) or the error dialog (failure), so a broken load fails fast with a clear message. The test intentionally does not click the tab — a failed load pops a modal that would correctly block a click — so the failure surfaces as a clean assertion instead of a click timeout.

## Selectors (all verified against nrp-frontend source)

- Error dialog: `.error-dialog` (react-bootstrap Modal `className="error-dialog"`, applied to the `role="dialog"` node) + `.error-dialog-message` — `src/components/dialog/error-dialog.js`.
- Files panel: `.flexlayout__tab_button:has-text('Edit experiment files')` (tool name in `experiment-tools-service.js` / default layout in `experiment-workbench.js`), `.tf-editor-container`, `select[name="selectTFFile"]` — `src/components/tf-editor/tf-editor.js`.
- Error message string "Could not load the experiment files." — `tf-editor.js` `dataError` handler.

## Verification

- `python -m py_compile tests/acceptance/test_ui_experiment.py` — OK.
- All selectors confirmed present in the nrp-frontend source.
- **Red-before-fix, run against the currently-running stack (UNFIXED `nrp-frontend:development` image):** the new test fails fast and cleanly with exactly the expected signal, proving it detects the shipped bug and that every selector matches the real DOM:

  ```
  AssertionError: an error dialog is shown after opening the experiment files panel: ['Could not load the experiment files.']
  1 failed, 10 deselected in 4.70s
  ```

- **Green proof is the orchestrator's job:** running `tests/run_acceptance.sh` against a live stack built on the **FIXED** frontend image (sibling PR), where the files load and the test passes. Not runnable here because the running stack carries the unfixed image (by design, that is what produces the red signal above).

## Merge order / dependency (important)

This is a **red-before-green** test PR: it is *designed to fail* until the sibling nrp-frontend EBR2-122 fix lands. Consequently this PR's own `acceptance` GitHub Actions check (which runs against the published `hbpneurorobotics/nrp-frontend:development` image via `docker-compose.yaml`) will stay **red** until that fix is merged and the `:development` image is rebuilt/republished.

Sequence:
1. Merge the sibling nrp-frontend EBR2-122 fix to `development`; wait for the `:development` frontend image to republish.
2. Re-run this PR's `acceptance` check (or `tests/run_acceptance.sh` against the refreshed stack) — it goes green.
3. Merge this PR.

A red `acceptance` check on this PR before step 1 is expected, not a defect.
